### PR TITLE
feat: added support for profile id in hyper

### DIFF
--- a/src/Types.res
+++ b/src/Types.res
@@ -50,7 +50,7 @@ type hyperInstance = {
   widgets: JSON.t => element,
   paymentRequest: JSON.t => JSON.t,
 }
-type hyperInstanceMake = (string, option<JSON.t>, JSON.t) => hyperInstance
+type hyperInstanceMake = (JSON.t, option<JSON.t>, JSON.t) => hyperInstance
 
 let confirmPaymentFn = (_elements: JSON.t) => {
   Promise.resolve(Dict.make()->JSON.Encode.object)


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix
- [X] New feature
- [ ] Enhancement
- [ ] Refactoring
- [ ] Dependency updates
- [ ] Documentation
- [ ] CI/CD

---

## **Description**

<!-- Describe your changes in detail -->
<!-- Mention any relevant issues or feature requests (e.g., Fixes #123 or Implements #456) -->
Added support for accepting profile id in hyper, Now we will accept JSON instead of string but for maintaining backward compatibility string can also be accepted.
The JSON will have publishable key and profile id.
---

## **How did you test it?**

<!--
Provide detailed information on testing:
- Did you add or update unit tests?
- How did you manually verify the changes (e.g., screenshots, console logs)?
- Have you verified it works in consuming projects?
-->
Tested via taking the latest build and running it locally

---

## **Usage Notes**

<!-- Provide information about how this change impacts package consumers:
- Are there breaking changes?
- Any new APIs or configuration options added?
- Backward compatibility ensured?
-->

---

## **Version Update**

- [ ] I have bumped the package version in `package.json` following semantic versioning:
  - `x.x.x` for major changes (breaking).
  - `x.x.x` for minor changes (new feature, no breaking changes).
  - `x.x.x` for patch changes (bug fixes, minor improvements).

---

## **Checklist**

<!-- Put an `x` in the boxes that apply -->

- [X] I ran `npm run re:build` and verified the build artifacts.
- [X] I reviewed the code for style, readability, and consistency.
- [X] I verified the changes are backward compatible (if applicable).
- [ ] I tested this change in a real or simulated consuming project.
- [ ] I updated documentation, README, or usage examples if necessary.

---

## **Screenshots or Logs**

<!-- Add relevant screenshots, console logs, or output to help reviewers understand the change -->
<!-- Optional, remove if not applicable -->
