### PR TITLE
feat: Allow custom script URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ loadStripe("YOUR_PUBLISHABLE_KEY", None);
 
 The script URL is determined based on your environment and key:
 
+- **Custom:** if you provide a URL starting with `http://` or `https://` it will be used directly.
 - **Sandbox:** `https://beta.hyperswitch.io/v1/HyperLoader.js`
 - **Production:** `https://checkout.hyperswitch.io/v0/HyperLoader.js`
 - **Fallback:** Determines based on the prefix of the provided key (`pk_prd_`).

--- a/src/Index.res
+++ b/src/Index.res
@@ -13,13 +13,22 @@ let loadHyper = (hyperObject: JSON.t, option: option<JSON.t>) => {
   Promise.make((resolve, reject) => {
     let sessionID = generateSessionID()
     let timeStamp = Date.now()
-    let scriptURL = switch getEnv(option) {
-    | "SANDBOX" => "https://beta.hyperswitch.io/v1/HyperLoader.js"
-    | "PROD" => "https://checkout.hyperswitch.io/v0/HyperLoader.js"
-    | _ =>
-      str->String.startsWith("pk_prd_")
-        ? "https://checkout.hyperswitch.io/v0/HyperLoader.js"
-        : "https://beta.hyperswitch.io/v1/HyperLoader.js"
+    let scriptURL = {
+      let isFullUrl = str => str->String.startsWith("https://") || str->String.startsWith("http://")
+      switch true {
+      | _ when isFullUrl(str) => str
+      | _ =>
+        switch getEnv(option) {
+        | "SANDBOX" => "https://beta.hyperswitch.io/v1/HyperLoader.js"
+        | "PROD" => "https://checkout.hyperswitch.io/v0/HyperLoader.js"
+        | _ =>
+          if str->String.startsWith("pk_prd_") {
+            "https://checkout.hyperswitch.io/v0/HyperLoader.js"
+          } else {
+            "https://beta.hyperswitch.io/v1/HyperLoader.js"
+          }
+        }
+      }
     }
     let analyticsObj =
       [


### PR DESCRIPTION
## Type of Change

<!-- Put an `x` in the boxes that apply -->

- [ ] Bugfix  
- [ ] New feature  
- [x] Enhancement  
- [ ] Refactoring  
- [ ] Dependency updates  
- [ ] Documentation  
- [ ] CI/CD  

---

## **Description**

This PR enhances the `loadHyper` function to allow passing a full script URL via the `publishableKey` field.

If the provided `scriptURL` starts with `http://` or `https://`, it will now be treated as a direct URL to the `HyperLoader.js` script, overriding the default logic based on environment or key prefix. This makes it possible to load a custom or self-hosted version of the Hyperswitch loader.

---

## **How did you test it?**

- Manually verified that passing a full URL as `publishableKey` correctly loads the specified script.
- Confirmed fallback logic continues to load the appropriate default script for regular keys (`pk_*`).
- Ensured duplicate loader warning is still respected.
- Tested integration inside a real app using a custom Hyperswitch instance.

---

## **Usage Notes**

- ✅ No breaking changes.
- 🔧 New optional behavior for advanced users.
- Consumers can now do:

  ```ts
  loadHyper(publishableKey, {
      scriptURL: "https://my-custom-script.com/script.js",
  })
  ```

- Existing usage with `pk_test_*` or `pk_prd_*` remains unchanged.

---

## **Checklist**

<!-- Put an `x` in the boxes that apply -->

- [x] I ran `npm run re:build` and verified the build artifacts.  
- [x] I reviewed the code for style, readability, and consistency.  
- [x] I verified the changes are backward compatible (if applicable).  
- [x] I tested this change in a real or simulated consuming project.  
- [ ] I updated documentation, README, or usage examples if necessary.  

---

## **Screenshots or Logs**

N/A
